### PR TITLE
feat(llvm): migrate from LLVM 14 to LLVM 20 with updated API and import fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "ariadne"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,14 +289,15 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "llvm-sys"
-version = "140.1.2"
+version = "201.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b285f8682531b9b394dd9891977a2a28c47006e491bda944e1ca62ebab2664"
+checksum = "9bb947e8b79254ca10d496d0798a9ba1287dcf68e50a92b016fec1cc45bef447"
 dependencies = [
+ "anyhow",
  "cc",
  "lazy_static",
  "libc",
- "regex",
+ "regex-lite",
  "semver",
 ]
 
@@ -429,6 +436,12 @@ dependencies = [
  "memchr",
  "regex-syntax",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-2.0"
 rust-version = "1.64.0"
 
 [dependencies]
-llvm-sys = "140.0"
+llvm-sys = "201.0.1-rc1"
 itertools = "0.10.5"
 tempfile = "3.1"
 clap = { version = "4.3.4", features = ["cargo", "string", "wrap_help"] }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -56,7 +56,7 @@ pub fn max_steps() -> u64 {
 /// Compile time speculative execution of instructions. We return the
 /// final state of the cells, any print side effects, and the point in
 /// the code we reached.
-pub fn execute(instrs: &[AstNode], steps: u64) -> (ExecutionState, Option<Warning>) {
+pub fn execute(instrs: &'_ [AstNode], steps: u64) -> (ExecutionState<'_>, Option<Warning>) {
     let mut state = ExecutionState::initial(instrs);
     let outcome = execute_with_state(instrs, &mut state, steps, None);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ fn compile_file(matches: &ArgMatches) -> Result<(), ()> {
         .get_one::<String>("llvm-opt")
         .expect("Required argument");
     let llvm_opt = llvm_opt_raw.parse::<i64>().expect("Validated by clap");
-    llvm::optimise_ir(&mut llvm_module, llvm_opt);
+    llvm::optimise_ir(&mut llvm_module, llvm_opt.try_into().unwrap());
 
     // Compile the LLVM IR to a temporary object file.
     let object_file = NamedTempFile::new().map_err(|e| {


### PR DESCRIPTION
# Upgrade from LLVM 14 to LLVM 20

- Updated `LLVMBuildGEP2` and `LLVMBuildLoad2` to include required `LLVMTypeRef` arguments
- Replaced `LLVMBuildTrunc2` with `LLVMBuildTrunc`
- Removed obsolete `LLVMPassBuilderOptionsSetOptLevel` call
- Fixed `LLVMRunPasses` error handling with `LLVMGetErrorMessage`
- Removed unnecessary `unsafe` blocks in `optimise_ir`
- Clarified lifetime syntax in `execute` function
- Corrected imports for `llvm_sys` modules to resolve unresolved symbols
- Fixed type mismatches for `LLVMTargetRef` and other types